### PR TITLE
Automatic recursion and opt-out tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,20 @@ type Sample struct {
 	Gender Gender `default:"m"` // Supports aliased types
 
 	Slice       []string       `default:"[]"`
-	Map         []string       `default:"{}"`
+	Map         map[string]int `default:"{}"`
 	SliceByJSON []int          `default:"[1, 2, 3]"` // Supports JSON format
 	MapByJSON   map[string]int `default:"{\"foo\": 123}"`
 
 	Struct    OtherStruct  `default:"{}"`
 	StructPtr *OtherStruct `default:"{\"Foo\": 123}"`
+
+	OptOut OtherStruct `default:"-"` // Opt-out
 }
 
 type OtherStruct struct {
 	Hello  string `default:"world"` // Default tags in nested struct also work
-	Foo    string
-	Random int
+	Foo    string `default:"-"`
+	Random int    `default:"-"`
 }
 
 // SetDefaults implements defaults.Setter interface

--- a/defaults.go
+++ b/defaults.go
@@ -32,7 +32,7 @@ func Set(ptr interface{}) error {
 	}
 
 	for i := 0; i < t.NumField(); i++ {
-		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "" {
+		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "-" {
 			setField(v.Field(i), defaultVal)
 		}
 	}

--- a/defaults.go
+++ b/defaults.go
@@ -45,6 +45,10 @@ func setField(field reflect.Value, defaultVal string) {
 		return
 	}
 
+	if isEquivalentToInitialValue(field.Kind(), defaultVal) {
+		return
+	}
+
 	if isInitialValue(field) {
 		switch field.Kind() {
 		case reflect.Bool:
@@ -111,20 +115,20 @@ func setField(field reflect.Value, defaultVal string) {
 		case reflect.Slice:
 			ref := reflect.New(field.Type())
 			ref.Elem().Set(reflect.MakeSlice(field.Type(), 0, 0))
-			if defaultVal != "[]" {
+			if defaultVal != "" && defaultVal != "[]" {
 				json.Unmarshal([]byte(defaultVal), ref.Interface())
 			}
 			field.Set(ref.Elem().Convert(field.Type()))
 		case reflect.Map:
 			ref := reflect.New(field.Type())
 			ref.Elem().Set(reflect.MakeMap(field.Type()))
-			if defaultVal != "{}" {
+			if defaultVal != "" && defaultVal != "{}" {
 				json.Unmarshal([]byte(defaultVal), ref.Interface())
 			}
 			field.Set(ref.Elem().Convert(field.Type()))
 		case reflect.Struct:
 			ref := reflect.New(field.Type())
-			if defaultVal != "{}" {
+			if defaultVal != "" && defaultVal != "{}" {
 				json.Unmarshal([]byte(defaultVal), ref.Interface())
 			}
 			field.Set(ref.Elem())
@@ -148,4 +152,18 @@ func setField(field reflect.Value, defaultVal string) {
 
 func isInitialValue(field reflect.Value) bool {
 	return reflect.DeepEqual(reflect.Zero(field.Type()).Interface(), field.Interface())
+}
+
+func isEquivalentToInitialValue(kind reflect.Kind, tag string) bool {
+	switch kind {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.String:
+		return (tag == "")
+	}
+
+	return false
 }


### PR DESCRIPTION
## Why

To fix https://github.com/creasty/defaults/issues/1

To follow the conventions of tag-based manipulation.

## What

- Automatically initialize fields that have no `default:` tag
- Add support for implicit opt-out by `default:"-"`