### PR TITLE
Added support for pointers to primitive values (non-struct)

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -153,8 +153,10 @@ func setField(field reflect.Value, defaultVal string) error {
 
 	switch field.Kind() {
 	case reflect.Ptr:
-		setField(field.Elem(), defaultVal)
-		callSetter(field.Interface())
+		if field.IsNil() || field.Elem().Kind() == reflect.Struct {
+			setField(field.Elem(), defaultVal)
+			callSetter(field.Interface())
+		}
 	case reflect.Struct:
 		if err := Set(field.Addr().Interface()); err != nil {
 			return err

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -44,10 +44,12 @@ type Sample struct {
 	Float64   float64       `default:"1.64"`
 	BoolTrue  bool          `default:"true"`
 	BoolFalse bool          `default:"false"`
+	BoolPtr   *bool         `default:"true"`
 	String    string        `default:"hello"`
 	Duration  time.Duration `default:"10s"`
 
 	IntOct    int    `default:"0o1"`
+	IntOctPtr *int   `default:"0o1"`
 	Int8Oct   int8   `default:"0o10"`
 	Int16Oct  int16  `default:"0o20"`
 	Int32Oct  int32  `default:"0o40"`
@@ -258,11 +260,17 @@ func TestInit(t *testing.T) {
 		if sample.BoolFalse != false {
 			t.Errorf("it should initialize bool (false)")
 		}
+		if *sample.BoolPtr == true {
+			t.Errorf("it should initialize bool (true)")
+		}
 		if sample.String != "hello" {
 			t.Errorf("it should initialize string")
 		}
 
 		if sample.IntOct != 0o1 {
+			t.Errorf("it should initialize int with octal literal")
+		}
+		if *sample.IntOctPtr != 0o1 {
 			t.Errorf("it should initialize int with octal literal")
 		}
 		if sample.Int8Oct != 0o10 {
@@ -577,6 +585,22 @@ func TestPointerStructMember(t *testing.T) {
 	Set(&m)
 	if m.Child.Age != 20 {
 		t.Errorf("20 is expected")
+	}
+}
+
+func TestPointerNonStructMember(t *testing.T) {
+	falseVal := false
+	intVal := 10
+	m := Sample{
+		IntOctPtr: &intVal,
+		BoolPtr:   &falseVal,
+	}
+	Set(&m)
+	if *m.BoolPtr != false {
+		t.Errorf("BoolPtr with valid value should not be modified by Set")
+	}
+	if *m.IntOctPtr != 10 {
+		t.Errorf("IntOctPtr with valid value should not be modified by Set")
 	}
 }
 


### PR DESCRIPTION
Usually, in our projects, we read a JSON configuration file into a struct and invoke the defaults.Set() function to set the default values of non initialized fields. When one of the configuration parameters is a boolean and we set its default value to true, it cannot use the JSON configuration file to set it as false, because Set() assumes it using the default value and modifies it to true. In order to solve this, we decided to use pointers to boolean that can be nil when the field does not appear in the configuration file. In such a scenario, defaults.Set() works fine as expected assigning true to the boolean field, however, when in the JSON configuration file the boolean parameter is set to false, then defaults.Set() ignores that the pointer already has a value different from nil, gets the pointer value, checks that it is false, and modifies it to true what is not desired.   

As a proposal, this PR just skips the setFields() function when the pointer is not nil and not a struct. Using this approach, the nil value will be the trigger to set the default value which makes sense since the Zero() value for pointers is nil.