### PR TITLE
tagged defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/*

--- a/defaults.go
+++ b/defaults.go
@@ -34,6 +34,16 @@ func Set(ptr interface{}) error {
 
 	for i := 0; i < t.NumField(); i++ {
 		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "-" {
+			if t.Field(i).IsExported() {
+				iface := v.Field(i).Addr().Interface()
+				if taggedSetter, ok := iface.(TaggedSetter); ok {
+					if err := taggedSetter.SetTaggedDefaults(defaultVal); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+
 			if err := setField(v.Field(i), defaultVal); err != nil {
 				return err
 			}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -755,5 +756,46 @@ func TestDefaultsSetter(t *testing.T) {
 	}
 	if main.MainInt != 1 {
 		t.Errorf("expected 1 for MainInt, got %d", main.MainInt)
+	}
+}
+
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) SetTaggedDefaults(tag string) (err error) {
+	d.Duration, err = time.ParseDuration(tag)
+	return
+}
+
+type TaggedDefaults struct {
+	Duration Duration `default:"1s"`
+}
+
+func TestTaggedDefaultsSetterHappy(t *testing.T) {
+	sample := &TaggedDefaults{}
+	err := Set(sample)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if sample.Duration.Duration != time.Second {
+		t.Errorf("expected 1s for Duration, got %s", sample.Duration.Duration)
+	}
+}
+
+type TaggedDefaultsSad struct {
+	Duration Duration `default:"invalid"`
+}
+
+func TestTaggedDefaultsSetterSad(t *testing.T) {
+	sample := &TaggedDefaultsSad{}
+	err := Set(sample)
+	if err == nil {
+		t.Error("unexpected success?!")
+	}
+
+	if !strings.HasPrefix(err.Error(), "time: invalid duration") {
+		t.Errorf("unexpected error: %s", err)
 	}
 }

--- a/setter.go
+++ b/setter.go
@@ -10,3 +10,14 @@ func callSetter(v interface{}) {
 		ds.SetDefaults()
 	}
 }
+
+type TaggedSetter interface {
+	SetTaggedDefaults(tag string) error
+}
+
+func callTaggedSetter(v interface{}, tag string) error {
+	if ds, ok := v.(TaggedSetter); ok {
+		return ds.SetTaggedDefaults(tag)
+	}
+	return nil
+}


### PR DESCRIPTION
Hey there! I'd love to be able to set a custom default for a type based on the tag like so:

```go
type Duration struct {
	time.Duration
}

func (d *Duration) SetTaggedDefaults(tag string) (err error) {
	d.Duration, err = time.ParseDuration(tag)
	return
}

type TaggedDefaults struct {
	Duration Duration `default:"1s"`
}

sample := &TaggedDefaults{}
err := Set(sample)
if err != nil { t.Errorf("unexpected error: %s", err) }

if sample.Duration.Duration != time.Second { t.Errorf("expected 1s for Duration, got %s", sample.Duration.Duration) }
```

This PR adds the interface and modifies the Set() logic to use it. Added tests to account for success and failure. All tests passing. Thanks!