### PR TITLE
fix: error when trying initialize slice of structs with `default` tag

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -169,7 +169,7 @@ func setField(field reflect.Value, defaultVal string) error {
 		}
 	case reflect.Slice:
 		for j := 0; j < field.Len(); j++ {
-			if err := setField(field.Index(j), defaultVal); err != nil {
+			if err := setField(field.Index(j), ""); err != nil {
 				return err
 			}
 		}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -144,6 +144,9 @@ type Sample struct {
 	NonInitialSlice     []int   `default:"[123]"`
 	NonInitialStruct    Struct  `default:"{}"`
 	NonInitialStructPtr *Struct `default:"{}"`
+
+	StructSliceWithEmptyDefaultElem  []Struct `default:"[{}]"`
+	StructSliceWithFilledDefaultElem []Struct `default:"[{\"WithDefault\":\"changed\"}]"`
 }
 
 type Struct struct {
@@ -678,6 +681,15 @@ func TestInit(t *testing.T) {
 		}
 		if sample.NoDefaultStruct.WithDefault != "" {
 			t.Errorf("it should not initialize a struct with default values")
+		}
+	})
+
+	t.Run("slice of structs", func(t *testing.T) {
+		if !reflect.DeepEqual(sample.StructSliceWithEmptyDefaultElem, []Struct{{Embedded: Embedded{Int: 1}, Foo: 0, Bar: 456, WithDefault: "foo"}}) {
+			t.Errorf("it should automatically fill a slice of structs with elements from default")
+		}
+		if !reflect.DeepEqual(sample.StructSliceWithFilledDefaultElem, []Struct{{Embedded: Embedded{Int: 1}, Foo: 0, Bar: 456, WithDefault: "changed"}}) {
+			t.Errorf("it should overwrite child's default with parent's")
 		}
 	})
 }


### PR DESCRIPTION
Hey! I've came across a same issue as [here](https://github.com/creasty/defaults/issues/14). It seems it can be solved by do not passing default tag value to `setField` if current field is a slice.