### PR TITLE
add test for bool default not to overwrite existing value

### DIFF
--- a/defaults_test.go
+++ b/defaults_test.go
@@ -140,6 +140,7 @@ type Sample struct {
 	StructWithNoTag            Struct
 	DeepSliceOfStructWithNoTag [][][]Struct
 
+	NonInitialBool      bool    `default:"true"`
 	NonInitialString    string  `default:"foo"`
 	NonInitialSlice     []int   `default:"[123]"`
 	NonInitialStruct    Struct  `default:"{}"`
@@ -189,6 +190,7 @@ func TestMustSet(t *testing.T) {
 			}
 		}()
 		sample := &Sample{
+			NonInitialBool:             false,
 			NonInitialString:           "string",
 			NonInitialSlice:            []int{1, 2, 3},
 			NonInitialStruct:           Struct{Foo: 123},
@@ -215,6 +217,7 @@ func TestMustSet(t *testing.T) {
 			}
 		}()
 		sample := Sample{
+			NonInitialBool:             false,
 			NonInitialString:           "string",
 			NonInitialSlice:            []int{1, 2, 3},
 			NonInitialStruct:           Struct{Foo: 123},
@@ -228,6 +231,7 @@ func TestMustSet(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	sample := &Sample{
+		NonInitialBool:             false,
 		NonInitialString:           "string",
 		NonInitialSlice:            []int{1, 2, 3},
 		NonInitialStruct:           Struct{Foo: 123},
@@ -577,6 +581,9 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("non-initial value", func(t *testing.T) {
+		if sample.NonInitialBool != false { // true is default; false is the non-initial value
+			t.Errorf("it should not override non-initial bool value")
+		}
 		if sample.NonInitialString != "string" {
 			t.Errorf("it should not override non-initial value")
 		}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -229,6 +229,33 @@ func TestMustSet(t *testing.T) {
 
 }
 
+func TestOverrideDefaultTrueBoolToFalse(t *testing.T) {
+	type example struct {
+		BoolTrue        bool  `default:"true"`
+		BoolPointerTrue *bool `default:"true"`
+	}
+
+	e := &example{
+		BoolTrue:        false,
+		BoolPointerTrue: func() *bool { b := false; return &b }(), // lolsob
+	}
+
+	err := Set(e)
+	if err != nil {
+		t.Errorf("Set() should not return an error: %v", err)
+	}
+	t.Run("bool", func(t *testing.T) {
+		if e.BoolTrue == true {
+			t.Errorf("it should not override user-set false with the default of true")
+		}
+	})
+	t.Run("bool pointer", func(t *testing.T) {
+		if *e.BoolPointerTrue == true {
+			t.Errorf("it should not override user-set false with the default of true")
+		}
+	})
+}
+
 func TestInit(t *testing.T) {
 	sample := &Sample{
 		NonInitialBool:             false,


### PR DESCRIPTION
Demonstrates the issue in #49 that that a default of `true` will override an existing value of `false` for bool fields.