### PR TITLE
doc: update README to document *bool behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Initialize structs with default values
   - Scalar types
     - `int/8/16/32/64`, `uint/8/16/32/64`, `float32/64`
     - `uintptr`, `bool`, `string`
+      - `bool` values declared as a `*bool` allow for an unset boolean type. This helps distinguish the case where a default true bool is set to `false`.
   - Complex types
     - `map`, `slice`, `struct`
   - Nested types
@@ -46,7 +47,7 @@ type Sample struct {
 	Name    string `default:"John Smith"`
 	Age     int    `default:"27"`
 	Gender  Gender `default:"m"`
-	Working bool   `default:"true"`
+	Working *bool   `default:"true"`
 
 	SliceInt    []int    `default:"[1, 2, 3]"`
 	SlicePtr    []*int   `default:"[1, 2, 3]"`


### PR DESCRIPTION
`bool` values that are unset (zero value is `false`) or have been set to `false` are indistinguishable from one another. As a  result, `bool` values with default `true` that are set to `false` get overriden by the defaults library. 

If the user declares a `*bool` in their struct, then there are three possible setting for boolean: `true`, `false` and unset. 

Closes #49 
Related to #50