### PR TITLE
support custom defaults on types that implement encoding.TextUnmarshaler 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/golang:1.15.8
+      - image: circleci/golang:1.17.5
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Initialize structs with default values
 - Recursively initializes fields in a struct
 - Dynamically sets default values by:
   - Implementing the [`defaults.Setter`](./setter.go) interface, or
-  - Implementing [`encoding.TextUnmarshaller`](https://pkg.go.dev/encoding#TextUnmarshaler)
+  - Implementing [`encoding.TextUnmarshaller`](https://pkg.go.dev/encoding#TextUnmarshaler) (has precedence over `defaults.Setter`)
 - Preserves non-initial values from being reset with a default value
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Initialize structs with default values
   - Pointer types
     - e.g., `*SampleStruct`, `*int`
 - Recursively initializes fields in a struct
-- Dynamically sets default values by [`defaults.Setter`](./setter.go) interface
+- Dynamically sets default values by:
+  - Implementing the [`defaults.Setter`](./setter.go) interface, or
+  - Implementing [`encoding.TextUnmarshaller`](https://pkg.go.dev/encoding#TextUnmarshaler)
 - Preserves non-initial values from being reset with a default value
 
 

--- a/defaults.go
+++ b/defaults.go
@@ -34,7 +34,7 @@ func Set(ptr interface{}) error {
 
 	for i := 0; i < t.NumField(); i++ {
 		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "-" {
-			if t.Field(i).IsExported() && v.Field(i).IsZero() {
+			if t.Field(i).PkgPath == "" && v.Field(i).IsZero() {
 				iface := v.Field(i).Addr().Interface()
 
 				if tu, ok := iface.(encoding.TextUnmarshaler); ok {

--- a/defaults.go
+++ b/defaults.go
@@ -34,6 +34,18 @@ func Set(ptr interface{}) error {
 
 	for i := 0; i < t.NumField(); i++ {
 		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "-" {
+			if t.Field(i).IsExported() && v.Field(i).IsZero() {
+				iface := v.Field(i).Addr().Interface()
+
+				if tu, ok := iface.(encoding.TextUnmarshaler); ok {
+					if err := tu.UnmarshalText([]byte(defaultVal)); err != nil {
+						return err
+					}
+
+					continue
+				}
+			}
+
 			if err := setField(v.Field(i), defaultVal); err != nil {
 				return err
 			}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -721,6 +721,65 @@ func TestCanUpdate(t *testing.T) {
 	}
 }
 
+func TestTextUnmarshaler(t *testing.T) {
+	t.Run("value type", func(t *testing.T) {
+		timeout := &struct {
+			Timeout Duration `default:"10s"`
+		}{}
+
+		err := Set(timeout)
+		if err != nil {
+			t.Error("set failed")
+		}
+
+		if timeout.Timeout.Duration != 10*time.Second {
+			t.Errorf("it should initialize Duration with tag")
+		}
+	})
+
+	t.Run("nil pointer type", func(t *testing.T) {
+		timeout := &struct {
+			Timeout *Duration `default:"10s"`
+		}{}
+
+		err := Set(timeout)
+		if err != nil {
+			t.Error("set failed")
+		}
+
+		if timeout.Timeout.Duration != 10*time.Second {
+			t.Errorf("it should initialize Duration with tag")
+		}
+	})
+
+	t.Run("does not overwrite existing value", func(t *testing.T) {
+		timeout := &struct {
+			Timeout Duration `default:"10s"`
+		}{
+			Timeout: Duration{Duration: 200 * time.Millisecond},
+		}
+
+		err := Set(timeout)
+		if err != nil {
+			t.Error("set failed")
+		}
+
+		if timeout.Timeout.Duration != 200*time.Millisecond {
+			t.Errorf("Set overwrote existing value to (%s)", timeout.Timeout.Duration)
+		}
+	})
+}
+
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
+
 type Child struct {
 	Name string `default:"Tom"`
 	Age  int    `default:"20"`

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -766,6 +767,21 @@ func TestTextUnmarshaler(t *testing.T) {
 
 		if timeout.Timeout.Duration != 200*time.Millisecond {
 			t.Errorf("Set overwrote existing value to (%s)", timeout.Timeout.Duration)
+		}
+	})
+
+	t.Run("reports error when unmarshaling fails", func(t *testing.T) {
+		timeout := &struct {
+			Timeout Duration `default:"garbage"`
+		}{}
+
+		err := Set(timeout)
+		if err == nil {
+			t.Error("Set should return error")
+		}
+
+		if !strings.Contains(err.Error(), "invalid duration") {
+			t.Errorf("Set should return error with invalid duration")
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/creasty/defaults
 
-go 1.14
+go 1.17


### PR DESCRIPTION
This is pretty much the same proposal as in https://github.com/creasty/defaults/pull/45 except for:

* we reuse the standard `encoding.TextUnmarshaler` interface
* we uphold the guarantee of `Preserves non-initial values from being reset with a default value`
* a mention in the `README`