### PR TITLE
Adopt #55: duration tags tolerate surrounding whitespace

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -228,10 +228,9 @@ func parseByMethod(field reflect.Value, defaultVal string) bool {
 			duration, err := time.ParseDuration(defaultVal)
 			if err == nil {
 				field.Set(reflect.ValueOf(duration))
-				return false
+				return true
 			}
 		}
-		return true
 	}
 	return false
 }

--- a/defaults.go
+++ b/defaults.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -63,6 +64,9 @@ func setField(field reflect.Value, defaultVal string) error {
 	isInitial := isInitialValue(field)
 	if isInitial {
 		if unmarshalByInterface(field, defaultVal) {
+			return nil
+		}
+		if parseByMethod(field, defaultVal) {
 			return nil
 		}
 
@@ -213,6 +217,21 @@ func unmarshalByInterface(field reflect.Value, defaultVal string) bool {
 		if err := asJSON.UnmarshalJSON([]byte(defaultVal)); err == nil {
 			return true
 		}
+	}
+	return false
+}
+
+func parseByMethod(field reflect.Value, defaultVal string) bool {
+	if field.Type() == reflect.TypeOf(time.Duration(0)) {
+		if defaultVal != "" {
+			defaultVal = strings.TrimSpace(defaultVal)
+			duration, err := time.ParseDuration(defaultVal)
+			if err == nil {
+				field.Set(reflect.ValueOf(duration))
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -312,6 +312,9 @@ func TestInit(t *testing.T) {
 		if sample.String != "hello" {
 			t.Errorf("it should initialize string")
 		}
+		if sample.Duration != 10000000000 {
+			t.Errorf("it should initialize time.Duration")
+		}
 
 		if sample.IntOct != 0o1 {
 			t.Errorf("it should initialize int with octal literal")


### PR DESCRIPTION
Adopts #55 by @boskuv. Their three commits are merged in **as their own commits**, so `git log` and the contributor graph credit them, then a second commit simplifies the implementation.

> **Note on #55's status:** deliberately *no* closing keyword here, as an experiment. On #73 the `Closes #64` keyword closed that PR before GitHub's merge-detection could mark it *merged*, so it shows "Closed" despite its commit being in `master`. Leaving the keyword off gives detection a clear run at marking #55 *merged* instead. If it doesn't work, #55 gets closed by hand with a comment — either way it will not be left dangling.

## What #55 actually changes

Narrower than its title suggests. I applied the patch and diffed the behavior against `master` across the whole matrix; exactly one cell moved:

| Case | master | with #55 |
| --- | --- | --- |
| `time.Duration` `default:"10s"` | 10s | 10s |
| `time.Duration` `default:" 10s "` | **0s** | **10s** ← the only change |
| `time.Duration` `default:"1"` | 1ns | 1ns |
| `type myDur time.Duration` `default:"10s"` | 10s | 10s |
| `int64` `default:"1h"` | 3600000000000 | 3600000000000 |

So this is a whitespace-tolerance fix, and **it does not close #66** — `Duration default:"1"` is still 1 nanosecond and a plain `int64` still accepts `"1h"`. #66 stays open, and no pinned test flips, which is itself the evidence: the suite went green straight after the merge, because whitespace was an input nothing exercised.

## Then simplified

`parseByMethod` duplicated the `ParseDuration` call already in the `int64` branch, so the second commit does the trim at that call site instead. Net source diff for the entire PR:

```go
+	"strings"
...
 		case reflect.Int64:
-			if val, err := time.ParseDuration(defaultVal); err == nil {
+			if val, err := time.ParseDuration(strings.TrimSpace(defaultVal)); err == nil {
```

Fourteen lines become one, and it fixes a gap in the original: `parseByMethod` keyed off `time.Duration`'s exact type, so `type myDuration time.Duration` was left out. The `int64` branch is kind-based, so named duration types are covered — `TestSet_DurationTagIsTrimmed` asserts that specifically.

The numeric fallback stays strict: `TestSet_NumberTagIsNotTrimmed` pins that `int default:" 1 "` still leaves the field alone, so the change is scoped to the duration attempt rather than loosening tag parsing generally.

## Backward compatibility

Additive. A padded duration tag went from silently producing zero to parsing; no input that worked before behaves differently.

## A note for #66

Worth recording while it is fresh: reflection **cannot** distinguish `type myDur time.Duration` from `type myCount int64` — both are `Kind() == Int64` with no link back to `time.Duration`. So the obvious fix for #66, restricting `ParseDuration` to duration-typed fields, would necessarily break named duration types, which `TestSet_Duration` pins as working. #66 may not be cleanly fixable while keeping that support; the trade-off deserves stating there before anyone attempts it.

## Verified

- `go vet ./...`, `golangci-lint run`, `make cover` → 100.0%, and the suite under `GOTOOLCHAIN=go1.21.13`.
- **Mutation check**: replacing the trim with a no-op that still satisfies the import makes `TestSet_DurationTagIsTrimmed` fail. My first attempt at this check was invalid — dropping `TrimSpace` outright left `strings` unused, so the mutant failed to compile rather than failing a test, which proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjAoN3BBvc6dfT9pog3kMB